### PR TITLE
wget files into their own cache dir.

### DIFF
--- a/roles/system-software/handlers/main.yml
+++ b/roles/system-software/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart systemd-journald
   command: systemctl restart systemd-journald
+  when: ansible_connection != 'local'

--- a/roles/veyepar-secrets/defaults/main.yml
+++ b/roles/veyepar-secrets/defaults/main.yml
@@ -3,5 +3,11 @@
 user_name: videoteam
 
 # Dir that contains workin veyepar checkout with secrets in place
-# like on a developer's laptop
+# like on a developer's laptop,
+# best to pass this on the command line:
+# --extra-vars="{'veyepar_confs': '/home/carl/src/veyepar'}"
 # veyepar_confs: /home/carl/src/veyepar
+
+# Entity that produces and uploads, like DebConf Video Team, or NDV.
+# used for credits image and upload credentials
+publisher: dcvt

--- a/roles/veyepar-secrets/tasks/main.yml
+++ b/roles/veyepar-secrets/tasks/main.yml
@@ -10,8 +10,8 @@
   with_items:
   - dj/dj/local_settings.py # db pw, smtp
   - dj/scripts/pw.py # conf site, twitter, swift ...
-  - dj/scripts/client_secrets.json # youtube
-    # - dj/scripts/oauth2-{{ org }}.json # youtube (not really needed?)
+  - dj/scripts/client_secrets.json # youtube app keys (for veyepar?)
   - dj/scripts/bling/{{ org }}/ # secret title.svg :p
-  - dj/scripts/bling/ndv-169.png
+  - dj/scripts/bling/{{ publisher }}-169.png # credits slide
+  - dj/scripts/oauth2-{{ publisher }}.json # youtube credentials
   when: veyepar_confs is defined

--- a/scripts/d-i/stretch/preseed.cfg
+++ b/scripts/d-i/stretch/preseed.cfg
@@ -1,5 +1,5 @@
-# Ansible managed
-#### Contents of the preconfiguration file (for jessie)
+#### Contents of the preconfiguration file (for stretch)
+
 ### Localization
 # Preseeding only locale sets language, country and locale.
 d-i debian-installer/locale string en_US

--- a/scripts/mk_usb_installer.cfg
+++ b/scripts/mk_usb_installer.cfg
@@ -14,6 +14,9 @@ playbook_branch=master
 inventory_repo=
 inventory_branch=
 
+# Anything else you want to append to the kernel.
+more_appends=
+
 # where to get installer binaries:
 
 suite=stretch

--- a/scripts/mk_usb_installer.sh
+++ b/scripts/mk_usb_installer.sh
@@ -23,9 +23,13 @@ lc/playbook_repo=${playbook_repo} \\
 lc/playbook_branch=${playbook_branch} \\
 lc/inventory_repo=${inventory_repo} \\
 lc/inventory_branch=${inventory_branch} \\
+${more_appends} \\
 "
 
 appends="${preseed}  partman-auto/disk=${disk}  grub-installer/bootdev=${bootdev}  hostname=${hostname}  domain=${domain}  hw-detect/load_firmware=${load_firmware}  lc/playbook_repo=${playbook_repo}  lc/playbook_branch=${playbook_branch}  lc/inventory_repo=${inventory_repo}  lc/inventory_branch=${inventory_branch} "
+
+cache=cache/${suite}
+mkdir -p ${cache}; cd ${cache}
 
 # get and veriy the boot image
 # (hd-media dir because that is bunred into the SHA256SUMS file)
@@ -41,7 +45,9 @@ curl -OJ ${iso_loc}/SHA256SUMS
 grep ${iso} SHA256SUMS > ${iso}.SHA256SUM
 sha256sum --check ${iso}.SHA256SUM
 
-zcat hd-media/boot.img.gz|sudo dcfldd of=/dev/${dev}
+cd -
+
+zcat ${cache}/hd-media/boot.img.gz|sudo dcfldd of=/dev/${dev}
 # or good ol dd
 # zcat boot.img.gz|sudo dd of=/dev/${dev} conv=fdatasync
 
@@ -68,7 +74,7 @@ case $suite in
 
     *)
 
-        cp ${iso} ${iso}.SHA256SUM /media/${dev}
+        cp ${cache}/${iso} ${cache}/${iso}.SHA256SUM /media/${dev}
         cd /media/${dev}
         # check the iso image again, make sure it copied ok.
         sha256sum --check ${iso}.SHA256SUM

--- a/scripts/mk_usb_installer.sh
+++ b/scripts/mk_usb_installer.sh
@@ -29,7 +29,9 @@ ${more_appends} \\
 appends="${preseed}  partman-auto/disk=${disk}  grub-installer/bootdev=${bootdev}  hostname=${hostname}  domain=${domain}  hw-detect/load_firmware=${load_firmware}  lc/playbook_repo=${playbook_repo}  lc/playbook_branch=${playbook_branch}  lc/inventory_repo=${inventory_repo}  lc/inventory_branch=${inventory_branch} "
 
 cache=cache/${suite}
-mkdir -p ${cache}; cd ${cache}
+mkdir -p ${cache}
+
+(cd ${cache}
 
 # get and veriy the boot image
 # (hd-media dir because that is bunred into the SHA256SUMS file)
@@ -45,7 +47,7 @@ curl -OJ ${iso_loc}/SHA256SUMS
 grep ${iso} SHA256SUMS > ${iso}.SHA256SUM
 sha256sum --check ${iso}.SHA256SUM
 
-cd -
+)
 
 zcat ${cache}/hd-media/boot.img.gz|sudo dcfldd of=/dev/${dev}
 # or good ol dd


### PR DESCRIPTION
$cache - dir to wget img and iso files into so they don't clutter up the code dir.
keeps  different suite's files with the same name from stepping on each other:
cache/$suite/hd-media/boot.img.gz

more_appends - plumbing to send random kernel params, like 
more_appends=mirror/http/proxy=http://cnt5:8000/

