### PR TITLE
move dynamic values from static preseed files into templat rendered files.

### DIFF
--- a/roles/tftp-server/defaults/main.yml
+++ b/roles/tftp-server/defaults/main.yml
@@ -3,8 +3,6 @@ time_zone: UTC
 domain: video.debconf.org
 
 apt_proxy: false
-# Defaults to deb.debian.org | archive.ubuntu.com
-#mirror: deb.debian.org
 debian_version: stretch
 
 user_name: videoteam
@@ -19,7 +17,6 @@ playbook_branch: master
 #   point at your own github repo
 #inventory_repo: https://gitlab.com/yourname/ansible-inventory
 #inventory_branch: master
-
 
 # boot image sources
 debian_host: ftp.debian.org

--- a/roles/tftp-server/files/d-i/stretch/preseed.cfg
+++ b/roles/tftp-server/files/d-i/stretch/preseed.cfg
@@ -98,7 +98,7 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-d-i mirror/http/hostname string deb.debian.org
+# d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 # d-i mirror/http/proxy string http://dc10b:8000/
@@ -116,9 +116,9 @@ d-i passwd/make-user boolean true
 
 # To create a normal user account.
 d-i passwd/user-fullname string Video Team User
-d-i passwd/username string juser
+# d-i passwd/username string juser
 # or encrypted using an MD5 hash.
-d-i passwd/user-password-crypted password $6$rounds=656000$Eyjidoi$37d0kawG/M7YHEf3KHbKMDAueDvQnr5ocJriqoI/N./Qkfg/JQqT6H9KK2C4MMm1utt7yK3eOgXj1k.9TOaeh.
+# d-i passwd/user-password-crypted password $6$rounds=656000$Eyjidoi$37d0kawG/M7YHEf3KHbKMDAueDvQnr5ocJriqoI/N./Qkfg/JQqT6H9KK2C4MMm1utt7yK3eOgXj1k.9TOaeh.
 
 # The user account will be added to some standard initial groups. To
 # override that, use this.
@@ -130,7 +130,7 @@ d-i clock-setup/utc boolean true
 
 # You may set this to any valid setting for $TZ; see the contents of
 # /usr/share/zoneinfo/ for valid values.
-d-i time/zone string US/Central
+# d-i time/zone string US/Central
 
 # Controls whether to use NTP to set the clock during the install
 d-i clock-setup/ntp boolean true
@@ -434,3 +434,4 @@ d-i hw-detect/load_firmware boolean false
 # Install UEFI boot loader on top of non efi .. clober whatever.
 d-i partman-efi/non_efi_system boolean true
 
+d-i preseed/include string ../preseed_local_debian.cfg

--- a/roles/tftp-server/files/d-i/xenial/preseed.cfg
+++ b/roles/tftp-server/files/d-i/xenial/preseed.cfg
@@ -1,5 +1,5 @@
 # d-i preseed/include string preseed_video.cfg preseed_local.cfg
 # d-i user-setup/encrypt-home boolean false
 
-d-i preseed/include string preseed_disk.cfg preseed_video.cfg preseed_local.cfg
+d-i preseed/include string preseed_disk.cfg preseed_video.cfg preseed_local.cfg ../preseed_local_ubuntu.cfg
 

--- a/roles/tftp-server/files/d-i/xenial/preseed_local.cfg
+++ b/roles/tftp-server/files/d-i/xenial/preseed_local.cfg
@@ -5,15 +5,15 @@
 # $ printf "r00tme" | mkpasswd -s -m md5
 
 d-i passwd/user-fullname string Joe User
-d-i passwd/username string juser
-d-i passwd/user-password-crypted password $6$khprmotoVWYLZY2W$Gj5Y6p4R.LsXQdL2xf6umhInzZ9GCG6USXB0XIl86m5.IbqSOPXJ0mxVUE7y5kGFE/arHgExAxoz0kEULiplZ.
+# d-i passwd/username string juser
+# d-i passwd/user-password-crypted password $6$khprmotoVWYLZY2W$Gj5Y6p4R.LsXQdL2xf6umhInzZ9GCG6USXB0XIl86m5.IbqSOPXJ0mxVUE7y5kGFE/arHgExAxoz0kEULiplZ.
 
 # d-i user-setup/allow-password-weak boolean true
 
 # d-i time/zone string US/Pacific
-d-i time/zone string US/Central
+# d-i time/zone string US/Central
 
-d-i mirror/http/hostname string us.archive.ubuntu.com
+# d-i mirror/http/hostname string us.archive.ubuntu.com
 d-i mirror/http/directory string /ubuntu
 
 # note: other parts of the install process may use the cache too,

--- a/roles/tftp-server/tasks/d-i.yml
+++ b/roles/tftp-server/tasks/d-i.yml
@@ -12,3 +12,10 @@
   - d-i
   - ec
 
+- name: write preseed_local_flavor.cfg
+  template:
+    src: preseed_local.cfg.j2
+    dest: /srv/pxe/d-i/preseed_local_{{item.key}}.cfg
+  with_dict:
+    debian: "{{ debian_host }}"
+    ubuntu: "{{ ubuntu_host }}"

--- a/roles/tftp-server/templates/preseed_local.cfg.j2
+++ b/roles/tftp-server/templates/preseed_local.cfg.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+d-i mirror/http/hostname string {{ item.value }}
+d-i passwd/username string {{ user_name }}
+d-i passwd/user-password-crypted password {{ user_password_crypted }}
+d-i time/zone string {{ time_zone }}


### PR DESCRIPTION
removed the preseed lines for the things that change 
added an include ../preseed_local_debian.cfg to the end of stretch/preseed.cfg  (and ubuntu for ubuntu's)
./preseed_local_debian.cfg exists in the git checkout but the preseed values are blank so the installer will prompt the user
./preseed_local_debian.cfg.j2 is a template that will plug in values from inventory values.